### PR TITLE
Add authentication and role-based access control (#10)

### DIFF
--- a/src/static/admin.html
+++ b/src/static/admin.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin - Mergington Activities</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Admin Panel</h1>
+      <a href="index.html">← Back to activities</a>
+    </header>
+
+    <main>
+      <section id="login-section">
+        <h3>Log In</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username</label>
+            <input id="username" required />
+          </div>
+          <div class="form-group">
+            <label for="password">Password</label>
+            <input id="password" type="password" required />
+          </div>
+          <button type="submit">Log In</button>
+        </form>
+        <div id="login-message" class="hidden"></div>
+      </section>
+
+      <section id="manage-section" class="hidden">
+        <h3>Create Activity</h3>
+        <form id="create-form">
+          <div class="form-group">
+            <label for="act-name">Name</label>
+            <input id="act-name" required />
+          </div>
+          <div class="form-group">
+            <label for="act-desc">Description</label>
+            <input id="act-desc" required />
+          </div>
+          <div class="form-group">
+            <label for="act-schedule">Schedule</label>
+            <input id="act-schedule" required />
+          </div>
+          <div class="form-group">
+            <label for="act-max">Max participants</label>
+            <input id="act-max" type="number" min="1" value="10" required />
+          </div>
+          <button type="submit">Create Activity</button>
+        </form>
+        <div id="manage-message" class="hidden"></div>
+
+        <h3>Existing Activities</h3>
+        <div id="manage-activities">Loading activities...</div>
+      </section>
+    </main>
+
+    <footer>
+      <p>&copy; 2023 Mergington High School</p>
+    </footer>
+
+    <script src="admin.js"></script>
+  </body>
+</html>

--- a/src/static/admin.js
+++ b/src/static/admin.js
@@ -1,0 +1,134 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const loginForm = document.getElementById("login-form");
+  const loginMessage = document.getElementById("login-message");
+  const manageSection = document.getElementById("manage-section");
+  const manageMessage = document.getElementById("manage-message");
+  const createForm = document.getElementById("create-form");
+  const manageActivities = document.getElementById("manage-activities");
+
+  function showMessage(el, text, kind = "success") {
+    el.textContent = text;
+    el.className = kind;
+    el.classList.remove("hidden");
+    setTimeout(() => el.classList.add("hidden"), 4000);
+  }
+
+  function getAuthHeader() {
+    return sessionStorage.getItem("authToken");
+  }
+
+  async function fetchActivities() {
+    try {
+      const res = await fetch("/activities");
+      const activities = await res.json();
+      renderManageActivities(activities);
+    } catch (err) {
+      manageActivities.textContent = "Failed to load activities.";
+    }
+  }
+
+  function renderManageActivities(activities) {
+    manageActivities.innerHTML = "";
+    const list = document.createElement("div");
+    Object.keys(activities).forEach((name) => {
+      const card = document.createElement("div");
+      card.className = "activity-card";
+      const h4 = document.createElement("h4");
+      h4.textContent = name;
+      const del = document.createElement("button");
+      del.textContent = "Delete";
+      del.addEventListener("click", () => deleteActivity(name));
+      card.appendChild(h4);
+      card.appendChild(del);
+      list.appendChild(card);
+    });
+    manageActivities.appendChild(list);
+  }
+
+  async function deleteActivity(name) {
+    const token = getAuthHeader();
+    if (!token) return showMessage(manageMessage, "Not authenticated", "error");
+
+    try {
+      const res = await fetch(`/activities/${encodeURIComponent(name)}`, {
+        method: "DELETE",
+        headers: {
+          Authorization: token,
+        },
+      });
+
+      const body = await res.json();
+      if (res.ok) {
+        showMessage(manageMessage, body.message, "success");
+        fetchActivities();
+      } else {
+        showMessage(manageMessage, body.detail || "Error deleting", "error");
+      }
+    } catch (err) {
+      showMessage(manageMessage, "Network error", "error");
+    }
+  }
+
+  loginForm.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+    const token = "Basic " + btoa(`${username}:${password}`);
+
+    // Try a simple authenticated request to verify credentials
+    fetch("/activities", { headers: { Authorization: token } })
+      .then((r) => {
+        if (r.status === 401) throw new Error("Unauthorized");
+        // success
+        sessionStorage.setItem("authToken", token);
+        loginForm.reset();
+        manageSection.classList.remove("hidden");
+        showMessage(loginMessage, "Logged in successfully", "success");
+        fetchActivities();
+      })
+      .catch(() => {
+        showMessage(loginMessage, "Login failed", "error");
+      });
+  });
+
+  createForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const name = document.getElementById("act-name").value;
+    const desc = document.getElementById("act-desc").value;
+    const schedule = document.getElementById("act-schedule").value;
+    const max = parseInt(document.getElementById("act-max").value, 10);
+    const token = getAuthHeader();
+    if (!token) return showMessage(manageMessage, "Not authenticated", "error");
+
+    const params = new URLSearchParams({
+      activity_name: name,
+      description: desc,
+      schedule: schedule,
+      max_participants: String(max),
+    });
+
+    try {
+      const res = await fetch(`/activities?${params.toString()}`, {
+        method: "POST",
+        headers: { Authorization: token },
+      });
+      const body = await res.json();
+      if (res.ok) {
+        showMessage(manageMessage, body.message, "success");
+        createForm.reset();
+        fetchActivities();
+      } else {
+        showMessage(manageMessage, body.detail || "Error creating", "error");
+      }
+    } catch (err) {
+      showMessage(manageMessage, "Network error", "error");
+    }
+  });
+
+  // Expose a logout for convenience
+  window.adminLogout = function () {
+    sessionStorage.removeItem("authToken");
+    manageSection.classList.add("hidden");
+    showMessage(loginMessage, "Logged out", "success");
+  };
+});

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,9 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <nav class="top-nav">
+        <a href="admin.html">Admin panel</a>
+      </nav>
     </header>
 
     <main>


### PR DESCRIPTION
Implements basic HTTP Basic authentication and role-based access control (admin/teacher). Adds admin endpoints to create and delete activities; keeps public signup/unregister endpoints. Seeds demo users: admin/adminpass and teacher/teacherpass. See issue #10.